### PR TITLE
Encoding to convert number into a short URL link

### DIFF
--- a/Atomizer/src/main/java/senghout/github/com/atomizer/AtomizerUtils.java
+++ b/Atomizer/src/main/java/senghout/github/com/atomizer/AtomizerUtils.java
@@ -1,0 +1,15 @@
+package senghout.github.com.atomizer;
+
+public class AtomizerUtils {
+    public static String encodeNumber(int number) {
+        String letters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        int size = letters.length();
+        int count = 6;
+        char[] shortURL = new char[7];
+        while (count >= 0) {
+            shortURL[count--] = letters.charAt(number % size);
+            number /= size;
+        }
+        return new String(shortURL);
+    }
+}


### PR DESCRIPTION
Created a helper function that will convert any number into a 62 encoded string that ranges from 09azAZ